### PR TITLE
Trace substitution

### DIFF
--- a/lib/honeybadger.js
+++ b/lib/honeybadger.js
@@ -100,7 +100,7 @@ Badger.prototype.makePayload = function (err, meta, cb) {
 
   if (!server.hostname) server.hostname = os.hostname();
   if (!server.environment_name) server.environment_name = process.env.NODE_ENV;
-  server.project_root = { path: process.cwd() };
+  server.project_root = process.cwd();
 
   if (meta.cgi_data) {
     meta.cgi_data = this._formatCGIData(meta.cgi_data);

--- a/lib/honeybadger.js
+++ b/lib/honeybadger.js
@@ -54,16 +54,17 @@ Badger.prototype._post = function (data) {
   });
 };
 
-Badger.prototype._wrapError = function (err) {
+Badger.prototype._wrapError = function (err, cb) {
   var trace = stackTrace.parse(err),
       output = {};
+  if (!cb) cb = function(f) { return f };
 
   output.backtrace = trace.map(function (c) {
-    return {
+    return cb({
       number: c.lineNumber,
       file: c.fileName,
       method: c.methodName || c.functionName
-    };
+    });
   });
 
   output.message = err.message || err.code || 'Error!';
@@ -113,9 +114,14 @@ Badger.prototype.makePayload = function (err, meta, cb) {
     delete meta.headers;
   }
 
+  var backtraceFilter = function(f) {
+    f.file = f.file.replace(server.project_root, '[PROJECT_ROOT]')
+    return f;
+  };
+
   var payload = {
     notifier: this._notifier,
-    error: this._wrapError(err),
+    error: this._wrapError(err, backtraceFilter),
     request: meta,
     server: server
   };

--- a/lib/honeybadger.js
+++ b/lib/honeybadger.js
@@ -100,7 +100,7 @@ Badger.prototype.makePayload = function (err, meta, cb) {
 
   if (!server.hostname) server.hostname = os.hostname();
   if (!server.environment_name) server.environment_name = process.env.NODE_ENV;
-  server.project_root = process.cwd();
+  if (!server.project_root) server.project_root = process.cwd();
 
   if (meta.cgi_data) {
     meta.cgi_data = this._formatCGIData(meta.cgi_data);

--- a/lib/honeybadger.js
+++ b/lib/honeybadger.js
@@ -115,7 +115,10 @@ Badger.prototype.makePayload = function (err, meta, cb) {
   }
 
   var backtraceFilter = function(f) {
-    f.file = f.file.replace(server.project_root, '[PROJECT_ROOT]')
+    if (f.file) {
+      f.file = f.file.replace(/.*\/node_modules\/(.+)/, '[NODE_MODULES]/$1');
+      f.file = f.file.replace(server.project_root, '[PROJECT_ROOT]');
+    }
     return f;
   };
 

--- a/test/honeybadger.js
+++ b/test/honeybadger.js
@@ -85,7 +85,7 @@ suite('node.js honeybadger.io notifier', function () {
       });
       hb.send(new Error('test error 3'));
     });
-    
+
     test('correctly sets the notifier field in the payload', function () {
       var n;
       n = payloads[payloads.length - 1].notifier;


### PR DESCRIPTION
This substitutes "[PROJECT_ROOT]" for the configured project_root (default: `pwd`) in stack frame file names, which will enable some special features in the Honeybadger UI such as linking to files on GitHub. It also attempts to first substitute "[NODE_MODULES]" for any node_modules paths since in many cases those reside within the project root directory (and do not usually reside within the code repository). The method of discovering the node_modules paths is a bit naive (a simple regexp); I've been looking for a way to programmatically get a list of node_modules paths but haven't found it yet. Suggestions welcome. :)