### PR TITLE
Request Metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
+### Added
+- Use `Honeybadger.metricsHandler` to send us request metrics!
 
 ## [1.0.0] - 2016-04-21
-
 ### Changed
 - Entirely new API. See the [README](README.md) for details!

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ In order to function properly our middleware must be added before and after your
 
 ```javascript
 app.use(Honeybadger.requestHandler); // Use *before* all other app middleware.
+app.use(Honeybadger.metricsHandler); // Optional; send request metrics (requires a Medium plan or better).
 // app.use(myMiddleware);
 app.use(Honeybadger.errorHandler);  // Use *after* all other app middleware.
 // app.use(myErrorMiddleware);
@@ -333,7 +334,7 @@ other_hb.notify("This will go to an alternate project.");
 
 ---
 
-### `Honeybadger.errorHandler()`: middleware for Express and Connect
+### `Honeybadger.errorHandler()`: error handling middleware for Express and Connect
 
 The `errorHandler` method is an error reporting middleware for [Express](http://expressjs.com/) and [Connect](https://github.com/senchalabs/connect#readme) apps. Use the middleware in your app to report all errors which happen during the request. Request data such as params, session, and cookies will be automatically reported.
 
@@ -341,6 +342,18 @@ The `errorHandler` method is an error reporting middleware for [Express](http://
 
 ```javascript
 app.use(Honeybadger.errorHandler);
+```
+
+---
+
+### `Honeybadger.metricsHandler()`: request metrics middleware for Express and Connect
+
+The `metricsHandler` method is a middleware for [Express](http://expressjs.com/) and [Connect](https://github.com/senchalabs/connect#readme) apps. Use the middleware in your app to send request metrics to Honeybadger (available via the "Metrics" dashboard for your project). Requires a Medium plan or better.
+
+#### Examples:
+
+```javascript
+app.use(Honeybadger.metricsHandler);
 ```
 
 ---

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -29,5 +29,6 @@ function backend(path) {
 }
 
 module.exports = {
-  notice: backend('/v1/notices')
+  notice: backend('/v1/notices'),
+  metrics: backend('/v1/metrics')
 }

--- a/lib/honeybadger.js
+++ b/lib/honeybadger.js
@@ -37,7 +37,7 @@ function Honeybadger(opts) {
 
   self.errorHandler = middleware.errorHandler.bind(self);
   self.requestHandler = middleware.requestHandler.bind(self);
-  self.metricHandler = middleware.metricHandler.bind(self);
+  self.metricsHandler = middleware.metricsHandler.bind(self);
   self.lambdaHandler = middleware.lambdaHandler.bind(self);
 
   self.apiKey = process.env.HONEYBADGER_API_KEY;

--- a/lib/honeybadger.js
+++ b/lib/honeybadger.js
@@ -7,6 +7,7 @@ var backend = require('./backend');
 var logger = require('./logger');
 var notice = require('./notice');
 var middleware = require('./middleware');
+var metricsCollector = require('./metrics');
 var configOpts = ['apiKey', 'endpoint', 'projectRoot', 'environment',
   'hostname', 'developmentEnvironments', 'logger'];
 var uncaughtExceptionInstalled;
@@ -16,14 +17,18 @@ function Honeybadger(opts) {
 
   EventEmitter.call(self);
 
+  var metrics = metricsCollector.call(self, { interval: 10000 });
+
   self.configure = configure;
   self.setContext = setContext;
   self.resetContext = resetContext;
   self.wrap = wrap;
   self.notify = notify;
+  self.timing = metrics.timing;
 
   self.errorHandler = middleware.errorHandler.bind(self);
   self.requestHandler = middleware.requestHandler.bind(self);
+  self.metricHandler = middleware.metricHandler.bind(self);
   self.lambdaHandler = middleware.lambdaHandler.bind(self);
 
   self.apiKey = process.env.HONEYBADGER_API_KEY;

--- a/lib/honeybadger.js
+++ b/lib/honeybadger.js
@@ -7,7 +7,7 @@ var backend = require('./backend');
 var logger = require('./logger');
 var notice = require('./notice');
 var middleware = require('./middleware');
-var metricsCollector = require('./metrics');
+var metricsFactory = require('./metrics');
 var configOpts = ['apiKey', 'endpoint', 'projectRoot', 'environment',
   'hostname', 'developmentEnvironments', 'logger'];
 var uncaughtExceptionInstalled;
@@ -17,15 +17,23 @@ function Honeybadger(opts) {
 
   EventEmitter.call(self);
 
-  var metrics = metricsCollector.call(self, { interval: 10000 });
+  var metrics = metricsFactory.call(self);
+
+  function collectMetrics() {
+    metrics.collect();
+    setTimeout(collectMetrics, self.metricsInterval);
+  }
+  process.nextTick(collectMetrics.bind(this));
+
+  self.metricsInterval = 60000;
+  self.timing = metrics.timing;
+  self.counter = metrics.counter;
 
   self.configure = configure;
   self.setContext = setContext;
   self.resetContext = resetContext;
   self.wrap = wrap;
   self.notify = notify;
-  self.timing = metrics.timing;
-  self.counter = metrics.counter;
 
   self.errorHandler = middleware.errorHandler.bind(self);
   self.requestHandler = middleware.requestHandler.bind(self);

--- a/lib/honeybadger.js
+++ b/lib/honeybadger.js
@@ -27,7 +27,7 @@ function Honeybadger(opts) {
 
   self.metricsInterval = 60000;
   self.timing = metrics.timing;
-  self.counter = metrics.counter;
+  self.increment = metrics.increment;
 
   self.configure = configure;
   self.setContext = setContext;

--- a/lib/honeybadger.js
+++ b/lib/honeybadger.js
@@ -25,6 +25,7 @@ function Honeybadger(opts) {
   self.wrap = wrap;
   self.notify = notify;
   self.timing = metrics.timing;
+  self.counter = metrics.counter;
 
   self.errorHandler = middleware.errorHandler.bind(self);
   self.requestHandler = middleware.requestHandler.bind(self);

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -1,0 +1,81 @@
+'use strict';
+
+var backend = require('./backend').metrics;
+var stats = require('./stats');
+
+function metrics(opts) {
+  if (!opts) { var opts = {}; }
+
+  var collector;
+  var counters = {};
+  var timings = {};
+
+  function collect() {
+    var metrics = [];
+    var name;
+
+    for (name in counters) {
+      metrics.push(name + " " + counts[name]);
+    }
+
+    for (name in timings) {
+      metrics.push(name + ":mean " + stats.mean(timings[name]));
+      metrics.push(name + ":median " + stats.median(timings[name]));
+      metrics.push(name + ":percentile_90 " + stats.percentile90(timings[name]));
+      metrics.push(name + ":min " + stats.min(timings[name]));
+      metrics.push(name + ":max " + stats.max(timings[name]));
+      metrics.push(name + ":stddev " + stats.std(timings[name]));
+      metrics.push(name + " " + stats.len(timings[name]));
+    }
+
+    // Reset collectors.
+    counters = {};
+    timings = {};
+
+    if (metrics.length < 1) { return; }
+    if (this.developmentEnvironments.indexOf(this.environment) !== -1) { return; }
+
+    var payload = {
+      metrics: metrics,
+      environment_name: this.environment,
+      hostname: this.hostname
+    };
+
+    backend(this, payload, function(backendErr, res, body) {
+      if (!backendErr && res.statusCode !== 201) {
+        backendErr = new Error('Bad HTTP response: ' + res.statusCode);
+      }
+
+      if (backendErr) {
+        this.logger.error('Unable to notify Honeybadger: ' + backendErr);
+        return;
+      }
+
+      this.logger.info('POST to /v1/metrics successful', body);
+    }.bind(this));
+  }
+
+  function counter(name, increment) {
+    if (!counters[name]) { counters[name] = 0; }
+    counters[name] += increment;
+  }
+
+  function timing(name, duration) {
+    if (!timings[name]) { timings[name] = []; }
+    timings[name].push(duration);
+  }
+
+  function startCollector(interval) {
+    if (collector) { clearInterval(collector); }
+    collector = setInterval(collect.bind(this), opts.interval || 60000);
+  }
+
+  startCollector.call(this, opts);
+
+  return {
+    counter: counter.bind(this),
+    timing: timing.bind(this)
+  };
+}
+
+module.exports = metrics;

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -16,7 +16,7 @@ function metrics(opts) {
     var name;
 
     for (name in counters) {
-      metrics.push(name + " " + counts[name]);
+      metrics.push(name + " " + counters[name]);
     }
 
     for (name in timings) {
@@ -61,11 +61,13 @@ function metrics(opts) {
   function counter(name, increment) {
     if (!counters[name]) { counters[name] = 0; }
     counters[name] += increment;
+    return this;
   }
 
   function timing(name, duration) {
     if (!timings[name]) { timings[name] = []; }
     timings[name].push(duration);
+    return this;
   }
 
   function startCollector(interval) {

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -3,9 +3,7 @@
 var backend = require('./backend').metrics;
 var stats = require('./stats');
 
-function metrics(opts) {
-  if (!opts) { var opts = {}; }
-
+function metrics() {
   var collector;
   var counters = {};
   var timings = {};
@@ -69,13 +67,6 @@ function metrics(opts) {
     timings[name].push(duration);
     return this;
   }
-
-  function startCollector(interval) {
-    if (collector) { clearInterval(collector); }
-    collector = setInterval(collect.bind(this), opts.interval || 60000);
-  }
-
-  startCollector.call(this, opts);
 
   return {
     counter: counter.bind(this),

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -10,7 +10,8 @@ function metrics(opts) {
   var counters = {};
   var timings = {};
 
-  function collect() {
+  function collect(callback) {
+    if (!callback) { callback = function(){}; }
     var metrics = [];
     var name;
 
@@ -48,9 +49,11 @@ function metrics(opts) {
 
       if (backendErr) {
         this.logger.error('Unable to notify Honeybadger: ' + backendErr);
+        callback(backendErr);
         return;
       }
 
+      callback(null, body);
       this.logger.info('POST to /v1/metrics successful', body);
     }.bind(this));
   }
@@ -74,7 +77,8 @@ function metrics(opts) {
 
   return {
     counter: counter.bind(this),
-    timing: timing.bind(this)
+    timing: timing.bind(this),
+    collect: collect.bind(this)
   };
 }
 

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -56,9 +56,9 @@ function metrics() {
     }.bind(this));
   }
 
-  function counter(name, increment) {
+  function increment(name, value) {
     if (!counters[name]) { counters[name] = 0; }
-    counters[name] += increment;
+    counters[name] += value;
     return this;
   }
 
@@ -69,7 +69,7 @@ function metrics() {
   }
 
   return {
-    counter: counter.bind(this),
+    increment: increment.bind(this),
     timing: timing.bind(this),
     collect: collect.bind(this)
   };

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -14,6 +14,24 @@ function fullUrl(req) {
   });
 }
 
+function metricHandler(req, res, next) {
+  var startAt = process.hrtime();
+
+  var end = res.end;
+  res.end = function () {
+    var diff = process.hrtime(startAt);
+    var time = diff[0] * 1e3 + diff[1] * 1e-6;
+
+    end.apply(res, arguments);
+
+    var code = res.statusCode;
+    if (!code) { return; }
+    this.timing("app.request." + code, time)
+  }.bind(this);
+
+  return next();
+}
+
 function requestHandler(req, res, next) {
   var dom = domain.create();
   dom.on('error', next);
@@ -50,5 +68,6 @@ function lambdaHandler(handler) {
 module.exports = {
   errorHandler: errorHandler,
   requestHandler: requestHandler,
+  metricHandler: metricHandler,
   lambdaHandler: lambdaHandler
 };

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -14,7 +14,7 @@ function fullUrl(req) {
   });
 }
 
-function metricHandler(req, res, next) {
+function metricsHandler(req, res, next) {
   var startAt = process.hrtime();
 
   var end = res.end;
@@ -68,6 +68,6 @@ function lambdaHandler(handler) {
 module.exports = {
   errorHandler: errorHandler,
   requestHandler: requestHandler,
-  metricHandler: metricHandler,
+  metricsHandler: metricsHandler,
   lambdaHandler: lambdaHandler
 };

--- a/lib/stats.js
+++ b/lib/stats.js
@@ -39,6 +39,7 @@ function max(ary) {
 }
 
 function std(ary) {
+  if (len(ary) < 1) { return 0.0; }
   return math.std(ary);
 }
 

--- a/lib/stats.js
+++ b/lib/stats.js
@@ -1,0 +1,57 @@
+'use strict';
+
+var math = require('mathjs');
+
+function mean(ary) {
+  return math.mean(ary);
+}
+
+function median(ary) {
+  return math.median(ary);
+}
+
+function percentile(ary, threshold) {
+  if (len(ary) < 1) {
+    return 0.0;
+  }
+
+  if (len(ary) == 1) {
+    return ary[0];
+  }
+
+  ary.sort();
+
+  var index = math.floor((threshold/100.00)*len(ary)) + 1
+
+  return ary[index-1];
+}
+
+function percentile90(ary) {
+  return percentile(ary, 90);
+}
+
+function min(ary) {
+  return math.min(ary);
+}
+
+function max(ary) {
+  return math.max(ary);
+}
+
+function std(ary) {
+  return math.std(ary);
+}
+
+function len(ary) {
+  return ary.length;
+}
+
+module.exports = {
+  mean: mean,
+  median: median,
+  percentile90: percentile90,
+  min: min,
+  max: max,
+  std: std,
+  len: len
+};

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "test"
   },
   "dependencies": {
+    "mathjs": "^3.2.1",
     "request": "~2.34.0",
     "stack-trace": "~0.0.9"
   },

--- a/test/honeybadger.js
+++ b/test/honeybadger.js
@@ -29,6 +29,18 @@ describe('Honeybadger', function () {
     });
   });
 
+  describe('#timing()', function () {
+    it('is chainable', function () {
+      assert.equal(Honeybadger.timing('app.request.200', 1.0), Honeybadger);
+    });
+  });
+
+  describe('#counter()', function () {
+    it('is chainable', function () {
+      assert.equal(Honeybadger.counter('foo', 1), Honeybadger);
+    });
+  });
+
   describe('#factory()', function () {
     it('creates a new client instance', function () {
       Singleton.configure({

--- a/test/honeybadger.js
+++ b/test/honeybadger.js
@@ -35,9 +35,9 @@ describe('Honeybadger', function () {
     });
   });
 
-  describe('#counter()', function () {
+  describe('#increment()', function () {
     it('is chainable', function () {
-      assert.equal(Honeybadger.counter('foo', 1), Honeybadger);
+      assert.equal(Honeybadger.increment('foo', 1), Honeybadger);
     });
   });
 

--- a/test/metrics.js
+++ b/test/metrics.js
@@ -20,7 +20,7 @@ describe('Honeybadger metrics', function () {
 
       for (var i = 0; i < 100; i++) {
         metrics.timing('app.request.200', i);
-        metrics.counter('foo', i);
+        metrics.increment('foo', i);
       }
 
       metrics.collect(function() {

--- a/test/metrics.js
+++ b/test/metrics.js
@@ -1,0 +1,43 @@
+var assert = require('assert'),
+  sinon = require('sinon'),
+  nock = require('nock'),
+  metricsFactory = require('../lib/metrics'),
+  Singleton = require('../lib/honeybadger');
+
+describe('Honeybadger metrics', function () {
+  describe('#timing', function () {
+    it('sends metrics', function(done) {
+      var payloads = [];
+      var api = nock("https://api.honeybadger.io")
+        .post("/v1/metrics")
+        .reply(function(uri, requestBody) {
+          payloads.push(requestBody);
+          return [201, '{}'];
+        });
+
+      var client = Singleton.factory({ apiKey: 'fake api key', environment: 'test environment', hostname: 'test hostname' });
+      var metrics = metricsFactory.call(client);
+
+      for (var i = 0; i < 100; i++) {
+        metrics.timing('app.request.200', i);
+      }
+
+      metrics.collect(function() {
+        api.done();
+        assert.equal(payloads.length, 1);
+        assert.equal(payloads[0].hostname, 'test hostname');
+        assert.equal(payloads[0].environment_name, 'test environment');
+        assert.deepEqual(payloads[0].metrics, [
+          'app.request.200:mean 49.5',
+          'app.request.200:median 49.5',
+          'app.request.200:percentile_90 90',
+          'app.request.200:min 0',
+          'app.request.200:max 99',
+          'app.request.200:stddev 29.011491975882016',
+          'app.request.200 100'
+        ]);
+        done();
+      });
+    });
+  });
+});

--- a/test/metrics.js
+++ b/test/metrics.js
@@ -20,6 +20,7 @@ describe('Honeybadger metrics', function () {
 
       for (var i = 0; i < 100; i++) {
         metrics.timing('app.request.200', i);
+        metrics.counter('foo', i);
       }
 
       metrics.collect(function() {
@@ -28,6 +29,7 @@ describe('Honeybadger metrics', function () {
         assert.equal(payloads[0].hostname, 'test hostname');
         assert.equal(payloads[0].environment_name, 'test environment');
         assert.deepEqual(payloads[0].metrics, [
+          'foo 4950',
           'app.request.200:mean 49.5',
           'app.request.200:median 49.5',
           'app.request.200:percentile_90 90',

--- a/test/middleware.js
+++ b/test/middleware.js
@@ -75,6 +75,22 @@ describe('Express Middleware', function () {
       done();
     });
   });
+
+  it('reports metrics to Honeybadger', function(done) {
+    var app = express();
+
+    app.use(client.metricHandler);
+
+    client_mock.expects('timing').once().withArgs("app.request.404");
+
+    request(app.listen())
+    .get('/')
+    .end(function(err, res){
+      if (err) return done(err);
+      client_mock.verify();
+      done();
+    });
+  });
 });
 
 describe('Lambda Handler', function () {

--- a/test/middleware.js
+++ b/test/middleware.js
@@ -79,7 +79,7 @@ describe('Express Middleware', function () {
   it('reports metrics to Honeybadger', function(done) {
     var app = express();
 
-    app.use(client.metricHandler);
+    app.use(client.metricsHandler);
 
     client_mock.expects('timing').once().withArgs("app.request.404");
 

--- a/test/stats.js
+++ b/test/stats.js
@@ -3,7 +3,15 @@ var assert = require('assert'),
 
 describe('Stats', function () {
   describe('#percentile90', function () {
-    it('calls next', function() {
+    it('returns zero for no values', function() {
+      assert.equal(stats.percentile90([]),  0.0);
+    });
+
+    it('returns first value for a single value', function() {
+      assert.equal(stats.percentile90([1]),  1.0);
+    });
+
+    it('returns 90th percentile for multiple values', function() {
       var values = [];
 
       // 0..100
@@ -12,6 +20,67 @@ describe('Stats', function () {
       }
 
       assert(stats.percentile90(values) == 90, "Expected the 90th percentile of 100 to be 90.");
+    });
+  });
+
+  describe('#mean', function () {
+    it('calculates the mean of the collection', function() {
+      var values = [1, 2, 3, 4, 5, 6];
+
+      assert.equal(stats.mean(values), 3.5);
+    });
+  });
+
+  describe('#median', function () {
+    it('calculates the median of the collection', function() {
+      var values = [1, 2, 3, 4, 5, 6, 7];
+
+      assert.equal(stats.median(values), 4);
+    });
+  });
+
+  describe('#std', function () {
+    it('returns zero for no values', function() {
+      assert.equal(stats.std([]),  0.0);
+    });
+
+    it('returns zero for a single value', function() {
+      assert.equal(stats.std([101]),  0.0);
+    });
+
+    it('calculates the standard deviation of the collection', function() {
+      var values = [];
+
+      // 0..100
+      for (var i = 0; i < 100; i++) {
+        values.push(i);
+      }
+
+      assert.equal(stats.std(values), 29.011491975882016);
+    });
+  });
+
+  describe('#min', function () {
+    it('returns the minimum value from the collection', function() {
+      var values = [1, 2, 3, 4, 5];
+
+      assert.equal(stats.min(values), 1);
+    });
+  });
+
+  describe('#max', function () {
+    it('returns the maximum value from the collection', function() {
+      var values = [1, 2, 3, 4, 5];
+
+      assert.equal(stats.max(values), 5);
+    });
+  });
+
+  describe('#len', function () {
+    it('returns the length of values in the collection', function() {
+      var values = [2, 4, 6, 8];
+
+      assert.equal(stats.len(values), 4);
     });
   });
 });

--- a/test/stats.js
+++ b/test/stats.js
@@ -1,0 +1,17 @@
+var assert = require('assert'),
+  stats = require('../lib/stats');
+
+describe('Stats', function () {
+  describe('#percentile90', function () {
+    it('calls next', function() {
+      var values = [];
+
+      // 0..100
+      for (var i = 0; i < 100; i++) {
+        values.push(i);
+      }
+
+      assert(stats.percentile90(values) == 90, "Expected the 90th percentile of 100 to be 90.");
+    });
+  });
+});


### PR DESCRIPTION
This adds support for sending request metrics to Honeybadger. Connect/Express support is native (via a new `Honeybadger.metricsHandler` middleware), or you can use `Honeybadger.timing('app.request.NNN', 35)` (where `NNN` is the status code (i.e. `200`) and `35` is the duration in milliseconds) to send metrics from other frameworks or servers. It also adds a new `metricsInterval` config option which is `60000` (in milliseconds, e.g. 1 minute) by default.

Something to consider is that this introduces a new dependency on the [mathjs](https://www.npmjs.com/package/mathjs) package in order to do statistics. It wouldn't be terribly hard to remove this extra dependency by just writing our own stats functions (the code is already prepped for this). I just haven't done it because of time. :)