### PR TITLE
Schedule metrics interval on demand instead of recursively.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
+### Fixed
+- `setTimeout` is now called when metrics are recorded instead of recursively.
+  This fixes an issue in environments like AWS Lambda where the execution waits
+  for the event loop to empty.
+
+### Added
+- Use `Honeybadger.flushMetrics()` to clear the timeout interval and flush
+  metrics immediately.
 
 ## [1.1.1] - 2016-06-16
 ### Fixed

--- a/lib/honeybadger.js
+++ b/lib/honeybadger.js
@@ -19,15 +19,10 @@ function Honeybadger(opts) {
 
   var metrics = metricsFactory.call(self);
 
-  function collectMetrics() {
-    metrics.collect();
-    setTimeout(collectMetrics, self.metricsInterval);
-  }
-  process.nextTick(collectMetrics.bind(this));
-
   self.metricsInterval = 60000;
   self.timing = metrics.timing;
   self.increment = metrics.increment;
+  self.flushMetrics = metrics.collect;
 
   self.configure = configure;
   self.setContext = setContext;

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -11,9 +11,7 @@ function metrics() {
 
   function intervalCollect() {
     if (interval) { return; }
-    interval = setTimeout(function() {
-      collect.call(this);
-    }.bind(this), this.metricsInterval);
+    interval = setTimeout(collect.bind(this), this.metricsInterval);
   }
 
   function collect(callback) {

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -4,9 +4,17 @@ var backend = require('./backend').metrics;
 var stats = require('./stats');
 
 function metrics() {
+  var interval;
   var collector;
   var counters = {};
   var timings = {};
+
+  function intervalCollect() {
+    if (interval) { return; }
+    interval = setTimeout(function() {
+      collect.call(this);
+    }.bind(this), this.metricsInterval);
+  }
 
   function collect(callback) {
     if (!callback) { callback = function(){}; }
@@ -30,6 +38,12 @@ function metrics() {
     // Reset collectors.
     counters = {};
     timings = {};
+
+    // Clear the timeout interval since the collector is now empty.
+    if (interval) {
+      clearTimeout(interval);
+      interval = undefined;
+    }
 
     if (metrics.length < 1) { return; }
     if (this.developmentEnvironments.indexOf(this.environment) !== -1) { return; }
@@ -59,12 +73,14 @@ function metrics() {
   function increment(name, value) {
     if (!counters[name]) { counters[name] = 0; }
     counters[name] += value;
+    intervalCollect.call(this);
     return this;
   }
 
   function timing(name, duration) {
     if (!timings[name]) { timings[name] = []; }
     timings[name].push(duration);
+    intervalCollect.call(this);
     return this;
   }
 


### PR DESCRIPTION
- `setTimeout` is now called when metrics are recorded instead of recursively. This fixes an issue in environments like AWS Lambda (nodejs4.3 runtime) where the execution waits for the event loop to empty.
- Use `Honeybadger.flushMetrics()` to clear the timeout interval and flush metrics immediately.

With this change metrics must be first reported using `Honeybadger.timing()` or `Honeybadger.increment()` for the timeout to be set at all (in most cases it won't, at least at the moment). These methods will not be called by default from Lambda. If you did call them for some reason (for instance, if we ever support collecting metrics about Lambda executions) then you have two options: you can set `Honeybadger.metricsInterval` to a value less than your Lambda timeout (I don't recommend this approach because it could introduce race conditions) or you can call the new `Honeybadger.flushMetrics()` function before your handler returns (recommended). We'll probably do this automatically in the next version of `Honeybadger.lambdaHandler()`.

This PR should allow you to use `Honeybadger.notify` and `Honeybadger.wrap` reliably inside your nodejs4.3 handlers (without `Honeybadger.lambdaHandler()`).

Also note that `Honeybadger.lambdaHandler()` currently has issues (see #10) in the nodejs4.3 runtime which I'll be addressing in a subsequent PR.

cc #9 @WilHall @hexgnu