### PR TITLE
Lambda fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ adheres to [Semantic Versioning](http://semver.org/).
 - `setTimeout` is now called when metrics are recorded instead of recursively.
   This fixes an issue in environments like AWS Lambda where the execution waits
   for the event loop to empty.
+- `Honeybadger.lambdaHandler()` now re-throws errors as would be expected on the
+  nodejs 0.10.42 runtime.
+- Fixed a bug in `Honeybadger.lambdaHandler()` where callback was called without
+  original arguments (the new implementation uses `Honeybadger.wrap`).
 
 ### Added
 - Use `Honeybadger.flushMetrics()` to clear the timeout interval and flush

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ adheres to [Semantic Versioning](http://semver.org/).
   nodejs 0.10.42 runtime.
 - Fixed a bug in `Honeybadger.lambdaHandler()` where callback was called without
   original arguments (the new implementation uses `Honeybadger.wrap`).
+- Support nodejs4.3 runtime in `Honeybadger.lambdaHandler()`.
 
 ### Added
 - Use `Honeybadger.flushMetrics()` to clear the timeout interval and flush

--- a/lib/honeybadger.js
+++ b/lib/honeybadger.js
@@ -96,12 +96,23 @@ function resetContext(context) {
   return this;
 }
 
-function wrap(func) {
+function wrap(func, opts, callback) {
   if (!util.is('Function', func)) { func = function noop(){}; }
+
+  if (!callback && opts && util.is('Function', opts)) {
+    callback = opts;
+    opts = {};
+  }
+  if (!callback) { callback = function noop(){}; }
+
+  if (!opts) { opts = {} }
+  if (!opts.stackShift) { opts.stackShift = 3; }
 
   var dom = domain.create();
   dom.on('error', function(err) {
-    this.notify(err, {stackShift: 3});
+    this.notify(err, opts, function (backendErr, notice) {
+      callback(backendErr, err, notice);
+    });
   }.bind(this));
   func = dom.bind(func);
 
@@ -109,12 +120,13 @@ function wrap(func) {
     try {
       return func.apply(this, arguments);
     } catch(err) {
-      this.notify(err, {stackShift: 3});
+      this.notify(err, opts, function (backendErr, notice) {
+        callback(backendErr, err, notice);
+      });
       throw(err);
     }
   }.bind(this);
 }
-
 function notify(err, name, extra, callback) {
   if (!err) { err = {}; }
 

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -58,9 +58,10 @@ function lambdaHandler(handler) {
       this.wrap(handler, {stackShift: 4}, function(_backendErr, err, body) {
         context.fail(err);
       }).apply(this, arguments);
-    } else {
-      this.wrap(handler, {stackShift: 4}).apply(this, arguments);
+      return;
     }
+
+    this.wrap(handler, {stackShift: 4}).apply(this, arguments);
   }.bind(this);
 }
 

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -53,15 +53,9 @@ function errorHandler(err, req, res, next) {
 
 function lambdaHandler(handler) {
   return function lambdaHandler(event, context) {
-    var dom = require('domain').create();
-
-    dom.on('error', function(err) {
-      this.notify(err, function() {
-        context.fail(err);
-      });
-    }.bind(this));
-
-    process.nextTick(dom.bind(handler));
+    this.wrap(handler, {stackShift: 4}, function(_backendErr, err, body) {
+      context.fail(err);
+    }).apply(this, arguments);
   }.bind(this);
 }
 

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -52,10 +52,15 @@ function errorHandler(err, req, res, next) {
 }
 
 function lambdaHandler(handler) {
-  return function lambdaHandler(event, context) {
-    this.wrap(handler, {stackShift: 4}, function(_backendErr, err, body) {
-      context.fail(err);
-    }).apply(this, arguments);
+  return function lambdaHandler(event, context, callback) {
+    if (!callback) {
+      // Deprecated: Pre-nodejs4.3 runtime.
+      this.wrap(handler, {stackShift: 4}, function(_backendErr, err, body) {
+        context.fail(err);
+      }).apply(this, arguments);
+    } else {
+      this.wrap(handler, {stackShift: 4}).apply(this, arguments);
+    }
   }.bind(this);
 }
 

--- a/test/honeybadger.js
+++ b/test/honeybadger.js
@@ -135,6 +135,36 @@ describe('Honeybadger', function () {
         assert(Honeybadger.notify.called);
       });
     });
+
+    it('calls the callback as 2nd argument', function () {
+      var callback = sinon.spy();
+
+      // Call callbacks synchronously.
+      Honeybadger.notify = function(err, opts, cb) {
+        callback();
+      };
+
+      assert.throws(Honeybadger.wrap(function() {
+        throw(new Error('Badgers!'));
+      }, callback), /Badgers!/);
+
+      assert(callback.calledOnce);
+    });
+
+    it('calls the callback as 3rd argument', function () {
+      var callback = sinon.spy();
+
+      // Call callbacks synchronously.
+      Honeybadger.notify = function(err, opts, cb) {
+        callback();
+      };
+
+      assert.throws(Honeybadger.wrap(function() {
+        throw(new Error('Badgers!'));
+      }, {}, callback), /Badgers!/);
+
+      assert(callback.calledOnce);
+    });
   });
 
   describe('#notify()', function () {

--- a/test/middleware.js
+++ b/test/middleware.js
@@ -103,11 +103,15 @@ describe('Lambda Handler', function () {
       .reply(201, '{"id":"1a327bf6-e17a-40c1-ad79-404ea1489c7a"}')
   });
 
+  it('calls original handlers with arguments', function() {
+    var handlerFunc = sinon.spy();
+    var handler = Honeybadger.lambdaHandler(handlerFunc);
+    handler(1, 2, 3);
+    assert(handlerFunc.calledWith(1, 2, 3));
+  });
+
   it('reports errors to Honeybadger', function(done) {
     var context = {
-      fail: function() {
-        done("should never succeed.");
-      },
       fail: function(err) {
         api.done();
         done();
@@ -118,14 +122,13 @@ describe('Lambda Handler', function () {
       throw new Error("Badgers!");
     });
 
-    handler({}, context);
+    assert.throws(function(){
+      handler({}, context);
+    }, /Badgers!/);
   });
 
   it('reports async errors to Honeybadger', function(done) {
     var context = {
-      fail: function() {
-        done("should never succeed.");
-      },
       fail: function(err) {
         api.done();
         done();


### PR DESCRIPTION
- `Honeybadger.lambdaHandler()` now re-throws errors as would be expected on the nodejs 0.10.42 runtime.
- Fixed a bug in `Honeybadger.lambdaHandler()` where callback was called without original arguments (the new implementation uses `Honeybadger.wrap`).
- Support nodejs4.3 runtime in `Honeybadger.lambdaHandler()` (just proxies to `Honeybadger.wrap` for now).