### PR TITLE
Deprecate Honeybadger.wrap()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ adheres to [Semantic Versioning](http://semver.org/).
 - Use `Honeybadger.flushMetrics()` to clear the timeout interval and flush
   metrics immediately.
 
+### Changed
+- Deprecate `Honeybadger.wrap()`
+
 ## [1.1.1] - 2016-06-16
 ### Fixed
 - Bump *request* package to `~2.72.0` to fix security vulnerabilities. -@gazay

--- a/README.md
+++ b/README.md
@@ -104,14 +104,6 @@ try {
 }
 ```
 
-You can also use the `#wrap()` function to simplify the previous example:
-
-```javascript
-Honeybadger.wrap(function(){
-  throw(new Error('Badgers!'));
-})();
-```
-
 Note that re-throwing the exceptions will cause them to be reported by any additional error handlers that may catch them.
 
 ## Sample Application
@@ -243,26 +235,6 @@ Honeybadger.notify(err, function notifyCallback(err, notice) {
   // If there was no error, log the notice:
   console.log(notice); // { id: 'uuid' }
 });
-```
-
----
-
-### `Honeybadger.wrap()`: Wrap the given function in try/catch and report any exceptions
-
-It can be a pain to include try/catch blocks everywhere in your app. A slightly nicer option is to use `Honeybadger.wrap`. You pass it a function. It returns a new function which wraps your existing function in a try/catch block. Errors will be re-thrown after they are reported.
-
-#### Examples:
-
-```javascript
-Honeybadger.wrap(function(){
-  throw "oops";
-})();
-```
-
-Note that `wrap` returns a function. This makes it easy to use with async callbacks, as in the example below:
-
-```javascript
-myEventEmitter.on('event', Honeybadger.wrap(function(){ throw "oops"; }));
 ```
 
 ---

--- a/lib/honeybadger.js
+++ b/lib/honeybadger.js
@@ -96,14 +96,9 @@ function resetContext(context) {
   return this;
 }
 
+// Deprecated: will likely be removed or changed in the future.
 function wrap(func) {
   if (!util.is('Function', func)) { func = function noop(){}; }
-
-  var dom = domain.create();
-  dom.on('error', function(err) {
-    this.notify(err, {stackShift: 3});
-  }.bind(this));
-  func = dom.bind(func);
 
   return function wrapper() {
     try {

--- a/test/honeybadger.js
+++ b/test/honeybadger.js
@@ -123,18 +123,6 @@ describe('Honeybadger', function () {
       }), /Badgers!/);
       assert(Honeybadger.notify.called);
     });
-
-    it('reports async errors via #notify()', function () {
-      sinon.spy(Honeybadger, 'notify');
-      Honeybadger.wrap(function() {
-        setTimeout(function asyncThrow() {
-          throw(new Error('Badgers!'));
-        }, 0);
-      })();
-      process.nextTick(function asyncThrow() {
-        assert(Honeybadger.notify.called);
-      });
-    });
   });
 
   describe('#notify()', function () {


### PR DESCRIPTION
Honeybadger.wrap() exists in honeybadger-js (our client-side library)
for the purpose of wrapping callbacks in try/catch. In node This doesn't
take into account errors in asynchronous callbacks, and the synchronous
expectations of the current function (it must always re-throw) doesn't
play well with domains.

In the future I'd like to re-think how Honeybadger.wrap() should
*actually* work (if there is still a use case) and then either rewrite
or remove it.