### PR TITLE
Allow filters to be configurable

### DIFF
--- a/lib/honeybadger.js
+++ b/lib/honeybadger.js
@@ -9,7 +9,7 @@ var notice = require('./notice');
 var middleware = require('./middleware');
 var metricsFactory = require('./metrics');
 var configOpts = ['apiKey', 'endpoint', 'projectRoot', 'environment',
-  'hostname', 'developmentEnvironments', 'logger'];
+  'hostname', 'developmentEnvironments', 'logger', 'filters'];
 var uncaughtExceptionInstalled;
 
 function Honeybadger(opts) {


### PR DESCRIPTION
It seems that everything is in order (documentation, defaults & tests) to use filters as a configuration option except for including the `filters` key in the configuration options param.